### PR TITLE
feat: Phase A2 API contract + session tracking improvements

### DIFF
--- a/.github/prompts/session-resume.prompt.md
+++ b/.github/prompts/session-resume.prompt.md
@@ -85,7 +85,24 @@ After completing each item:
 2. If the item produces a file, verify it exists
 3. If a validation command is specified, run it
 
-### Step 5 — Update session state (MANDATORY before ending)
+### Step 5 — Sync GitHub issues (MANDATORY after each step)
+
+After completing each step, sync the corresponding GitHub
+issue using the issue-to-step mapping table in the session
+tracker:
+
+1. Read the "Issue-to-Step Mapping" table in the tracker
+2. For each completed step that has a mapped issue:
+   - Close the issue with `gh issue close <N> --comment "..."`
+   - Include a brief completion note (commit SHA, PR, or output file)
+3. Update the parent epic's task list checkboxes with
+   `gh issue edit <N> --body "..."`
+4. Update the mapping table status in the tracker
+
+This syncs the session tracker (file) with GitHub Issues
+(project management). Both must stay aligned.
+
+### Step 6 — Update session state (MANDATORY before ending)
 
 Before the session ends, update the session tracker:
 
@@ -93,7 +110,8 @@ Before the session ends, update the session tracker:
 2. Update the "Current Session Target" section with next step
 3. Append a row to the "Session Log" table
 4. Record any decisions made in the "Decisions Made" table
-5. Note any blockers discovered
+5. Update the "Issue-to-Step Mapping" status column
+6. Note any blockers discovered
 
 ## Output Expectations
 
@@ -109,5 +127,6 @@ Before the session ends, update the session tracker:
 - [ ] Only phase-relevant context was loaded
 - [ ] Correct branch is checked out
 - [ ] All completed items are checked off in the tracker
+- [ ] GitHub issues synced (closed/updated per mapping table)
 - [ ] Session log has a new entry for this session
 - [ ] No work was done outside the current phase's scope

--- a/docs/api-contract.md
+++ b/docs/api-contract.md
@@ -94,10 +94,10 @@ continuation tokens:
 
 #### GET /api/health
 
-| Field | Value                      |
-| ----- | -------------------------- |
-| Auth  | None (unauthenticated)     |
-| Role  | —                          |
+| Field | Value                  |
+| ----- | ---------------------- |
+| Auth  | None (unauthenticated) |
+| Role  | —                      |
 
 **Response 200:** `ApiResponse<HealthAPI.HealthCheckResponse>`
 
@@ -111,10 +111,10 @@ continuation tokens:
 
 #### POST /api/hackathons
 
-| Field      | Value                                 |
-| ---------- | ------------------------------------- |
-| Auth       | Required (GitHub OAuth via Easy Auth) |
-| Role       | Admin                                 |
+| Field | Value                                 |
+| ----- | ------------------------------------- |
+| Auth  | Required (GitHub OAuth via Easy Auth) |
+| Role  | Admin                                 |
 
 **Request body:** `HackathonsAPI.CreateRequest`
 
@@ -133,10 +133,10 @@ continuation tokens:
 
 #### GET /api/hackathons
 
-| Field      | Value                                 |
-| ---------- | ------------------------------------- |
-| Auth       | Required (GitHub OAuth via Easy Auth) |
-| Role       | Admin, Coach                          |
+| Field | Value                                 |
+| ----- | ------------------------------------- |
+| Auth  | Required (GitHub OAuth via Easy Auth) |
+| Role  | Admin, Coach                          |
 
 **Query parameters:** `HackathonsAPI.ListRequest`
 (`status?`, `continuationToken?`, `pageSize?`)
@@ -147,10 +147,10 @@ continuation tokens:
 
 #### PATCH /api/hackathons/:id
 
-| Field      | Value                                 |
-| ---------- | ------------------------------------- |
-| Auth       | Required (GitHub OAuth via Easy Auth) |
-| Role       | Admin                                 |
+| Field | Value                                 |
+| ----- | ------------------------------------- |
+| Auth  | Required (GitHub OAuth via Easy Auth) |
+| Role  | Admin                                 |
 
 **Request body:** `HackathonsAPI.UpdateRequest`
 
@@ -166,10 +166,10 @@ continuation tokens:
 
 #### POST /api/hackathons/:id/assign-teams
 
-| Field      | Value                                 |
-| ---------- | ------------------------------------- |
-| Auth       | Required (GitHub OAuth via Easy Auth) |
-| Role       | Admin                                 |
+| Field | Value                                 |
+| ----- | ------------------------------------- |
+| Auth  | Required (GitHub OAuth via Easy Auth) |
+| Role  | Admin                                 |
 
 **Request body:** `HackathonsAPI.AssignTeamsRequest`
 (`teamSize?` — overrides hackathon default)
@@ -223,10 +223,10 @@ Teams are balanced so no team has fewer than
 
 #### GET /api/teams
 
-| Field      | Value                                 |
-| ---------- | ------------------------------------- |
-| Auth       | Required (GitHub OAuth via Easy Auth) |
-| Role       | Admin, Coach                          |
+| Field | Value                                 |
+| ----- | ------------------------------------- |
+| Auth  | Required (GitHub OAuth via Easy Auth) |
+| Role  | Admin, Coach                          |
 
 **Query parameters:** `TeamsAPI.ListRequest`
 (`hackathonId` required, `continuationToken?`, `pageSize?`)
@@ -237,10 +237,10 @@ Teams are balanced so no team has fewer than
 
 #### PATCH /api/teams/:id/reassign
 
-| Field      | Value                                 |
-| ---------- | ------------------------------------- |
-| Auth       | Required (GitHub OAuth via Easy Auth) |
-| Role       | Admin                                 |
+| Field | Value                                 |
+| ----- | ------------------------------------- |
+| Auth  | Required (GitHub OAuth via Easy Auth) |
+| Role  | Admin                                 |
 
 **Request body:** `TeamsAPI.ReassignRequest`
 
@@ -262,18 +262,28 @@ Teams are balanced so no team has fewer than
 
 #### POST /api/rubrics
 
-| Field      | Value                                 |
-| ---------- | ------------------------------------- |
-| Auth       | Required (GitHub OAuth via Easy Auth) |
-| Role       | Admin                                 |
+| Field | Value                                 |
+| ----- | ------------------------------------- |
+| Auth  | Required (GitHub OAuth via Easy Auth) |
+| Role  | Admin                                 |
 
 **Request body:** `RubricsAPI.CreateRequest`
 
 ```json
 {
   "categories": [
-    { "id": "quality", "name": "Code Quality", "description": "Clean, readable code", "maxScore": 10 },
-    { "id": "creativity", "name": "Creativity", "description": "Novel approach", "maxScore": 20 }
+    {
+      "id": "quality",
+      "name": "Code Quality",
+      "description": "Clean, readable code",
+      "maxScore": 10
+    },
+    {
+      "id": "creativity",
+      "name": "Creativity",
+      "description": "Novel approach",
+      "maxScore": 20
+    }
   ]
 }
 ```
@@ -287,10 +297,10 @@ versioned docs pattern — activate via PATCH.
 
 #### GET /api/rubrics
 
-| Field      | Value                                 |
-| ---------- | ------------------------------------- |
-| Auth       | Required (GitHub OAuth via Easy Auth) |
-| Role       | Admin, Coach, Hacker                  |
+| Field | Value                                 |
+| ----- | ------------------------------------- |
+| Auth  | Required (GitHub OAuth via Easy Auth) |
+| Role  | Admin, Coach, Hacker                  |
 
 **Query parameters:** `RubricsAPI.ListRequest`
 (`activeOnly?`, `continuationToken?`, `pageSize?`)
@@ -301,10 +311,10 @@ versioned docs pattern — activate via PATCH.
 
 #### GET /api/rubrics/:id
 
-| Field      | Value                                 |
-| ---------- | ------------------------------------- |
-| Auth       | Required (GitHub OAuth via Easy Auth) |
-| Role       | Admin, Coach, Hacker                  |
+| Field | Value                                 |
+| ----- | ------------------------------------- |
+| Auth  | Required (GitHub OAuth via Easy Auth) |
+| Role  | Admin, Coach, Hacker                  |
 
 **Response 200:** `ApiResponse<RubricsAPI.RubricRecord>`
 
@@ -312,10 +322,10 @@ versioned docs pattern — activate via PATCH.
 
 #### PATCH /api/rubrics/:id
 
-| Field      | Value                                 |
-| ---------- | ------------------------------------- |
-| Auth       | Required (GitHub OAuth via Easy Auth) |
-| Role       | Admin                                 |
+| Field | Value                                 |
+| ----- | ------------------------------------- |
+| Auth  | Required (GitHub OAuth via Easy Auth) |
+| Role  | Admin                                 |
 
 **Request body:** `RubricsAPI.UpdateRequest`
 
@@ -368,10 +378,10 @@ Submission is created in `pending` state with `scores: null`.
 
 #### GET /api/submissions
 
-| Field      | Value                                 |
-| ---------- | ------------------------------------- |
-| Auth       | Required (GitHub OAuth via Easy Auth) |
-| Role       | Admin, Coach (all); Hacker (own team) |
+| Field | Value                                 |
+| ----- | ------------------------------------- |
+| Auth  | Required (GitHub OAuth via Easy Auth) |
+| Role  | Admin, Coach (all); Hacker (own team) |
 
 **Query parameters:** `SubmissionsAPI.ListRequest`
 (`hackathonId` required, `status?`, `teamId?`,
@@ -388,10 +398,10 @@ only their own team's submissions.
 
 #### PATCH /api/submissions/:id
 
-| Field      | Value                                 |
-| ---------- | ------------------------------------- |
-| Auth       | Required (GitHub OAuth via Easy Auth) |
-| Role       | Admin, Coach                          |
+| Field | Value                                 |
+| ----- | ------------------------------------- |
+| Auth  | Required (GitHub OAuth via Easy Auth) |
+| Role  | Admin, Coach                          |
 
 **Request body:** `SubmissionsAPI.ReviewRequest`
 
@@ -430,10 +440,10 @@ required.
 
 #### PATCH /api/scores/:id/override
 
-| Field      | Value                                 |
-| ---------- | ------------------------------------- |
-| Auth       | Required (GitHub OAuth via Easy Auth) |
-| Role       | Admin                                 |
+| Field | Value                                 |
+| ----- | ------------------------------------- |
+| Auth  | Required (GitHub OAuth via Easy Auth) |
+| Role  | Admin                                 |
 
 **Request body:** `ScoresAPI.OverrideRequest`
 
@@ -464,10 +474,10 @@ logged.
 
 #### GET /api/leaderboard/:hackathonId
 
-| Field      | Value                                 |
-| ---------- | ------------------------------------- |
-| Auth       | Required (GitHub OAuth via Easy Auth) |
-| Role       | Admin, Coach, Hacker                  |
+| Field | Value                                 |
+| ----- | ------------------------------------- |
+| Auth  | Required (GitHub OAuth via Easy Auth) |
+| Role  | Admin, Coach, Hacker                  |
 
 **Response 200:** `ApiResponse<LeaderboardAPI.LeaderboardResponse>`
 
@@ -491,10 +501,10 @@ Client-side auto-refresh polls every 30 seconds.
 
 #### POST /api/challenges
 
-| Field      | Value                                 |
-| ---------- | ------------------------------------- |
-| Auth       | Required (GitHub OAuth via Easy Auth) |
-| Role       | Admin                                 |
+| Field | Value                                 |
+| ----- | ------------------------------------- |
+| Auth  | Required (GitHub OAuth via Easy Auth) |
+| Role  | Admin                                 |
 
 **Request body:** `ChallengesAPI.CreateRequest`
 
@@ -514,10 +524,10 @@ Client-side auto-refresh polls every 30 seconds.
 
 #### GET /api/challenges
 
-| Field      | Value                                 |
-| ---------- | ------------------------------------- |
-| Auth       | Required (GitHub OAuth via Easy Auth) |
-| Role       | Admin, Coach, Hacker                  |
+| Field | Value                                 |
+| ----- | ------------------------------------- |
+| Auth  | Required (GitHub OAuth via Easy Auth) |
+| Role  | Admin, Coach, Hacker                  |
 
 **Query parameters:** `ChallengesAPI.ListRequest`
 (`hackathonId` required, `continuationToken?`, `pageSize?`)
@@ -531,10 +541,10 @@ Client-side auto-refresh polls every 30 seconds.
 
 #### GET /api/progression
 
-| Field      | Value                                 |
-| ---------- | ------------------------------------- |
-| Auth       | Required (GitHub OAuth via Easy Auth) |
-| Role       | Admin, Coach, Hacker                  |
+| Field | Value                                 |
+| ----- | ------------------------------------- |
+| Auth  | Required (GitHub OAuth via Easy Auth) |
+| Role  | Admin, Coach, Hacker                  |
 
 **Query parameters:** `ProgressionAPI.GetRequest`
 (`hackathonId` required, `teamId` required)
@@ -551,10 +561,10 @@ N+1 unlocks when Challenge N's submission is approved.
 
 #### POST /api/roles/invite
 
-| Field      | Value                                 |
-| ---------- | ------------------------------------- |
-| Auth       | Required (GitHub OAuth via Easy Auth) |
-| Role       | Admin                                 |
+| Field | Value                                 |
+| ----- | ------------------------------------- |
+| Auth  | Required (GitHub OAuth via Easy Auth) |
+| Role  | Admin                                 |
 
 **Request body:** `RolesAPI.InviteRequest`
 
@@ -577,10 +587,10 @@ N+1 unlocks when Challenge N's submission is approved.
 
 #### DELETE /api/roles/:id
 
-| Field      | Value                                 |
-| ---------- | ------------------------------------- |
-| Auth       | Required (GitHub OAuth via Easy Auth) |
-| Role       | Admin                                 |
+| Field | Value                                 |
+| ----- | ------------------------------------- |
+| Auth  | Required (GitHub OAuth via Easy Auth) |
+| Role  | Admin                                 |
 
 **Response 204:** No content
 
@@ -594,10 +604,10 @@ N+1 unlocks when Challenge N's submission is approved.
 
 #### GET /api/roles
 
-| Field      | Value                                 |
-| ---------- | ------------------------------------- |
-| Auth       | Required (GitHub OAuth via Easy Auth) |
-| Role       | Admin                                 |
+| Field | Value                                 |
+| ----- | ------------------------------------- |
+| Auth  | Required (GitHub OAuth via Easy Auth) |
+| Role  | Admin                                 |
 
 **Query parameters:** `RolesAPI.ListRequest`
 (`hackathonId` required, `continuationToken?`, `pageSize?`)
@@ -610,10 +620,10 @@ N+1 unlocks when Challenge N's submission is approved.
 
 #### GET /api/audit/:hackathonId
 
-| Field      | Value                                 |
-| ---------- | ------------------------------------- |
-| Auth       | Required (GitHub OAuth via Easy Auth) |
-| Role       | Admin                                 |
+| Field | Value                                 |
+| ----- | ------------------------------------- |
+| Auth  | Required (GitHub OAuth via Easy Auth) |
+| Role  | Admin                                 |
 
 **Query parameters:** `AuditAPI.ListRequest`
 (`hackathonId` in path, `action?`, `continuationToken?`,
@@ -630,10 +640,10 @@ Paginated, filterable log of all reviewer actions.
 
 #### GET /api/config
 
-| Field      | Value                                 |
-| ---------- | ------------------------------------- |
-| Auth       | Required (GitHub OAuth via Easy Auth) |
-| Role       | Admin                                 |
+| Field | Value                                 |
+| ----- | ------------------------------------- |
+| Auth  | Required (GitHub OAuth via Easy Auth) |
+| Role  | Admin                                 |
 
 **Response 200:** `ApiResponse<ConfigAPI.ConfigRecord[]>`
 
@@ -644,10 +654,10 @@ refresh interval, max team size, etc.).
 
 #### PATCH /api/config/:key
 
-| Field      | Value                                 |
-| ---------- | ------------------------------------- |
-| Auth       | Required (GitHub OAuth via Easy Auth) |
-| Role       | Admin                                 |
+| Field | Value                                 |
+| ----- | ------------------------------------- |
+| Auth  | Required (GitHub OAuth via Easy Auth) |
+| Role  | Admin                                 |
 
 **Request body:** `ConfigAPI.UpdateRequest`
 
@@ -666,48 +676,48 @@ refresh interval, max team size, etc.).
 
 ## Error Code Catalogue
 
-| Code  | Meaning                    | Common Causes                                              |
-| ----- | -------------------------- | ---------------------------------------------------------- |
-| `400` | Bad Request                | Zod validation failure, missing required field,            |
-|       |                            | score exceeds rubric max                                   |
-| `401` | Unauthorized               | Missing/invalid Easy Auth header, invalid event code       |
-| `403` | Forbidden                  | Insufficient role, cross-team access, primary admin        |
-|       |                            | demotion attempt, locked challenge submission              |
-| `404` | Not Found                  | Resource ID does not exist                                 |
-| `409` | Conflict                   | Duplicate submission, invalid state transition,            |
-|       |                            | already reviewed, user already has role                    |
-| `429` | Too Many Requests          | Rate limit exceeded (5/min/IP on join, 100/min/IP general) |
-| `500` | Internal Server Error      | Unexpected server error, Cosmos DB connectivity failure    |
+| Code  | Meaning               | Common Causes                                              |
+| ----- | --------------------- | ---------------------------------------------------------- |
+| `400` | Bad Request           | Zod validation failure, missing required field,            |
+|       |                       | score exceeds rubric max                                   |
+| `401` | Unauthorized          | Missing/invalid Easy Auth header, invalid event code       |
+| `403` | Forbidden             | Insufficient role, cross-team access, primary admin        |
+|       |                       | demotion attempt, locked challenge submission              |
+| `404` | Not Found             | Resource ID does not exist                                 |
+| `409` | Conflict              | Duplicate submission, invalid state transition,            |
+|       |                       | already reviewed, user already has role                    |
+| `429` | Too Many Requests     | Rate limit exceeded (5/min/IP on join, 100/min/IP general) |
+| `500` | Internal Server Error | Unexpected server error, Cosmos DB connectivity failure    |
 
 ---
 
 ## Endpoint Summary
 
-| #  | Method   | Path                              | Role(s)        | Phase |
-| -- | -------- | --------------------------------- | -------------- | ----- |
-| 1  | `GET`    | `/api/health`                     | —              | —     |
-| 2  | `POST`   | `/api/hackathons`                 | Admin          | 6     |
-| 3  | `GET`    | `/api/hackathons`                 | Admin, Coach   | 6     |
-| 4  | `PATCH`  | `/api/hackathons/:id`             | Admin          | 6     |
-| 5  | `POST`   | `/api/hackathons/:id/assign-teams`| Admin          | 6     |
-| 6  | `POST`   | `/api/join`                       | Any authed     | 6     |
-| 7  | `GET`    | `/api/teams`                      | Admin, Coach   | 6     |
-| 8  | `PATCH`  | `/api/teams/:id/reassign`         | Admin          | 6     |
-| 9  | `POST`   | `/api/rubrics`                    | Admin          | 7     |
-| 10 | `GET`    | `/api/rubrics`                    | All roles      | 7     |
-| 11 | `GET`    | `/api/rubrics/:id`                | All roles      | 7     |
-| 12 | `PATCH`  | `/api/rubrics/:id`                | Admin          | 7     |
-| 13 | `POST`   | `/api/submissions`                | Hacker         | 7     |
-| 14 | `GET`    | `/api/submissions`                | All roles      | 7     |
-| 15 | `PATCH`  | `/api/submissions/:id`            | Admin, Coach   | 7     |
-| 16 | `PATCH`  | `/api/scores/:id/override`        | Admin          | 7     |
-| 17 | `GET`    | `/api/leaderboard/:hackathonId`   | All roles      | 8     |
-| 18 | `POST`   | `/api/challenges`                 | Admin          | 9     |
-| 19 | `GET`    | `/api/challenges`                 | All roles      | 9     |
-| 20 | `GET`    | `/api/progression`                | All roles      | 9     |
-| 21 | `POST`   | `/api/roles/invite`               | Admin          | 10    |
-| 22 | `GET`    | `/api/roles`                      | Admin          | 10    |
-| 23 | `DELETE` | `/api/roles/:id`                  | Admin          | 10    |
-| 24 | `GET`    | `/api/audit/:hackathonId`         | Admin          | 10    |
-| 25 | `GET`    | `/api/config`                     | Admin          | 10    |
-| 26 | `PATCH`  | `/api/config/:key`                | Admin          | 10    |
+| #   | Method   | Path                               | Role(s)      | Phase |
+| --- | -------- | ---------------------------------- | ------------ | ----- |
+| 1   | `GET`    | `/api/health`                      | —            | —     |
+| 2   | `POST`   | `/api/hackathons`                  | Admin        | 6     |
+| 3   | `GET`    | `/api/hackathons`                  | Admin, Coach | 6     |
+| 4   | `PATCH`  | `/api/hackathons/:id`              | Admin        | 6     |
+| 5   | `POST`   | `/api/hackathons/:id/assign-teams` | Admin        | 6     |
+| 6   | `POST`   | `/api/join`                        | Any authed   | 6     |
+| 7   | `GET`    | `/api/teams`                       | Admin, Coach | 6     |
+| 8   | `PATCH`  | `/api/teams/:id/reassign`          | Admin        | 6     |
+| 9   | `POST`   | `/api/rubrics`                     | Admin        | 7     |
+| 10  | `GET`    | `/api/rubrics`                     | All roles    | 7     |
+| 11  | `GET`    | `/api/rubrics/:id`                 | All roles    | 7     |
+| 12  | `PATCH`  | `/api/rubrics/:id`                 | Admin        | 7     |
+| 13  | `POST`   | `/api/submissions`                 | Hacker       | 7     |
+| 14  | `GET`    | `/api/submissions`                 | All roles    | 7     |
+| 15  | `PATCH`  | `/api/submissions/:id`             | Admin, Coach | 7     |
+| 16  | `PATCH`  | `/api/scores/:id/override`         | Admin        | 7     |
+| 17  | `GET`    | `/api/leaderboard/:hackathonId`    | All roles    | 8     |
+| 18  | `POST`   | `/api/challenges`                  | Admin        | 9     |
+| 19  | `GET`    | `/api/challenges`                  | All roles    | 9     |
+| 20  | `GET`    | `/api/progression`                 | All roles    | 9     |
+| 21  | `POST`   | `/api/roles/invite`                | Admin        | 10    |
+| 22  | `GET`    | `/api/roles`                       | Admin        | 10    |
+| 23  | `DELETE` | `/api/roles/:id`                   | Admin        | 10    |
+| 24  | `GET`    | `/api/audit/:hackathonId`          | Admin        | 10    |
+| 25  | `GET`    | `/api/config`                      | Admin        | 10    |
+| 26  | `PATCH`  | `/api/config/:key`                 | Admin        | 10    |

--- a/docs/exec-plans/active/hackops-execution.md
+++ b/docs/exec-plans/active/hackops-execution.md
@@ -12,14 +12,36 @@
 
 ---
 
+## Issue-to-Step Mapping
+
+<!-- When a step completes, close the corresponding issue with a comment. -->
+<!-- When an epic's subtasks all complete, close the epic. -->
+
+| Step                      | Issue | Status          |
+| ------------------------- | ----- | --------------- |
+| Epic: Phase A             | #1    | Open (3/7 done) |
+| Epic: Phase C             | #2    | Open            |
+| A1: PRD                   | #3    | Closed          |
+| A2: API contract          | #4    | Closed          |
+| A3: Data model            | #5    | Open            |
+| A4: UI pages              | #6    | Open            |
+| A5: Env config            | #7    | Open            |
+| C1: App-dev agents        | #8    | Open            |
+| C3: App-dev skills        | #9    | Open            |
+| C4: App-dev instructions  | #10   | Open            |
+| C4: Register instructions | #11   | Open            |
+| C1: App-dev subagents     | #12   | Open            |
+
+---
+
 ## Current Session Target
 
 <!-- Update this at the START of each session -->
 
 **Phase**: A — Product Documentation
-**Step**: A2 — Run `doc-api-contract-generator.prompt.md` → produce `packages/shared/types/api-contract.ts` + `docs/api-contract.md`
+**Step**: A3 — Run `doc-data-model-generator.prompt.md` → produce `docs/data-model.md`
 **Branch**: `feature/product-docs`
-**Goal**: Generate the API contract types and reference doc
+**Goal**: Generate the Cosmos DB data model reference
 
 ---
 
@@ -41,7 +63,7 @@
 - [x] A0: Create `doc-api-contract-generator.prompt.md`
 - [x] A0: Create `doc-data-model-generator.prompt.md`
 - [x] A1: Run PRD generator → `docs/prd.md`
-- [ ] A2: Run API contract generator →
+- [x] A2: Run API contract generator →
       `packages/shared/types/api-contract.ts` + `docs/api-contract.md`
 - [ ] A3: Run data model generator → `docs/data-model.md`
 - [ ] A4: Create `docs/ui-pages.md`
@@ -173,20 +195,34 @@
 
 <!-- Append one entry per session. Keep entries concise. -->
 
-| #   | Date       | Phase/Step | What was done      | What's next        | Blockers |
-| --- | ---------- | ---------- | ------------------ | ------------------ | -------- |
-| 0   | 2026-02-24 | Planning   | Created blueprint, | B0: Bootstrap      | None     |
-|     |            |            | challenged, and    | issues, then start |          |
-|     |            |            | resolved 14        | Phase A            |          |
-|     |            |            | findings           |                    |          |
-| 1   | 2026-02-25 | A / A0     | Created 3 A0       | B0: Bootstrap      | B0 needs |
-|     |            |            | doc-gen prompts    | issues             | GH_TOKEN |
-| 2   | 2026-02-25 | B0         | Created 12 GitHub  | A1: Run PRD        | None     |
-|     |            |            | issues (#1-#12),   | generator prompt   |          |
-|     |            |            | epic label         |                    |          |
-| 3   | 2026-02-25 | A / A1     | Generated PRD with | A2: Run API        | None     |
-|     |            |            | 64 user stories,   | contract generator |          |
-|     |            |            | 8 domains, NFRs    |                    |          |
+| #   | Date       | Phase/Step | What was done         | What's next        | Blockers |
+| --- | ---------- | ---------- | --------------------- | ------------------ | -------- |
+| 0   | 2026-02-24 | Planning   | Created blueprint,    | B0: Bootstrap      | None     |
+|     |            |            | challenged, and       | issues, then start |          |
+|     |            |            | resolved 14           | Phase A            |          |
+|     |            |            | findings              |                    |          |
+| 1   | 2026-02-25 | A / A0     | Created 3 A0          | B0: Bootstrap      | B0 needs |
+|     |            |            | doc-gen prompts       | issues             | GH_TOKEN |
+| 2   | 2026-02-25 | B0         | Created 12 GitHub     | A1: Run PRD        | None     |
+|     |            |            | issues (#1-#12),      | generator prompt   |          |
+|     |            |            | epic label            |                    |          |
+| 3   | 2026-02-25 | A / A1     | Generated PRD with    | Adversarial review | None     |
+|     |            |            | 64 user stories,      | of PRD + add       |          |
+|     |            |            | 8 domains, NFRs       | challenger agents  |          |
+| 3b  | 2026-02-25 | Cross      | Created 3 adversarial | Fix 6 PRD design   | None     |
+|     |            |            | subagents (infra,     | decisions from     |          |
+|     |            |            | app-security,         | adversarial review |          |
+|     |            |            | app-logic); moved     |                    |          |
+|     |            |            | 10-Challenger to      |                    |          |
+|     |            |            | subagent; merged      |                    |          |
+|     |            |            | PR #14                |                    |          |
+| 3c  | 2026-02-25 | A / A1     | Fixed 6 PRD design    | A2: Run API        | None     |
+|     |            |            | decisions; aligned    | contract generator |          |
+|     |            |            | 7 files (15 edits)    |                    |          |
+| 4   | 2026-02-25 | A / A2     | Generated API         | A3: Run data model | None     |
+|     |            |            | contract: 26          | generator          |          |
+|     |            |            | endpoints, TS         |                    |          |
+|     |            |            | types + MD ref        |                    |          |
 
 ---
 
@@ -223,6 +259,12 @@ have enough context for the current step.
 
 <!-- Record any runtime decisions that deviate from the blueprint -->
 
-| Date | Decision | Rationale |
-| ---- | -------- | --------- |
-| —    | —        | —         |
+| Date       | Decision                                                   | Rationale                                                     |
+| ---------- | ---------------------------------------------------------- | ------------------------------------------------------------- |
+| 2026-02-25 | Hackers submit evidence; Coaches enter rubric scores       | Scoring authority belongs with Coaches, not Hackers           |
+| 2026-02-25 | Event codes stored as plaintext + rate limiting (5/min/IP) | SHA-256 hashing adds complexity without real security gain    |
+| 2026-02-25 | Tiebreaker: earliest last-approval timestamp wins          | Rewards faster completion when total scores are equal         |
+| 2026-02-25 | Unlimited evidence resubmissions allowed                   | Scores only entered by Coach on review; no reason to limit    |
+| 2026-02-25 | Team balance: `ceil(teamSize/2)` minimum per team          | Prevents runt teams of 1; balanced distribution is fairer     |
+| 2026-02-25 | Coach review queue is hackathon-scoped                     | Coaches should only see submissions for their assigned events |
+| 2026-02-25 | Moved 10-Challenger to infra-challenger-subagent           | Adversarial review is invoked by parent agents, not directly  |

--- a/packages/shared/types/api-contract.ts
+++ b/packages/shared/types/api-contract.ts
@@ -125,8 +125,7 @@ export namespace HackathonsAPI {
   export const PATHS = {
     base: "/api/hackathons",
     byId: (id: string) => `/api/hackathons/${id}` as const,
-    assignTeams: (id: string) =>
-      `/api/hackathons/${id}/assign-teams` as const,
+    assignTeams: (id: string) => `/api/hackathons/${id}/assign-teams` as const,
   } as const;
 }
 
@@ -435,8 +434,7 @@ export namespace AuditAPI {
   }
 
   export const PATHS = {
-    byHackathon: (hackathonId: string) =>
-      `/api/audit/${hackathonId}` as const,
+    byHackathon: (hackathonId: string) => `/api/audit/${hackathonId}` as const,
   } as const;
 }
 


### PR DESCRIPTION
## Phase A2 — API Contract

- `packages/shared/types/api-contract.ts` — 13 namespaces, 26 endpoints, TypeScript-clean
- `docs/api-contract.md` — full endpoint reference, Easy Auth docs, error catalogue

## Session Tracking Fixes

- Closed issues #3 (PRD) and #4 (API contract)
- Updated Epic #1 task list (A0/A1/A2 checked)
- Added Issue-to-Step Mapping table to session tracker
- Added mandatory Step 5 (Sync GitHub issues) to `session-resume.prompt.md`
- Backfilled missing session log entries (3b adversarial agents, 3c PRD fixes)
- Populated Decisions Made table with 7 design decisions

## Checklist
- [x] All lefthook checks pass (0 errors)
- [x] `tsc --noEmit --strict` clean
- [x] `npm run lint:md` passes (0 errors, 113 files)