### PR TITLE
fix(deploy): Add User Access Administrator role for OIDC deployer

### DIFF
--- a/docs/first-deploy-runbook.md
+++ b/docs/first-deploy-runbook.md
@@ -175,6 +175,12 @@ az role assignment create \
   --role "Contributor" \
   --scope "/subscriptions/<sub-id>/resourceGroups/rg-hackops-se-dev"
 
+# User Access Administrator on RG (create RBAC assignments in Bicep)
+az role assignment create \
+  --assignee "6507ac72-518a-4974-b834-3479efc93f4c" \
+  --role "User Access Administrator" \
+  --scope "/subscriptions/<sub-id>/resourceGroups/rg-hackops-se-dev"
+
 # AcrPush on ACR (push container images)
 az role assignment create \
   --assignee "6507ac72-518a-4974-b834-3479efc93f4c" \

--- a/scripts/setup-github-environments.sh
+++ b/scripts/setup-github-environments.sh
@@ -301,6 +301,30 @@ gh variable set AZURE_ALERT_EMAIL --repo "$REPO" --env "$ENV_NAME" --body "$TECH
 gh variable set ADMIN_GITHUB_IDS --repo "$REPO" --env "$ENV_NAME" --body "$ADMIN_GITHUB_IDS"
 echo "  8 variables written"
 
+# ── Assign Azure RBAC roles to deployer identity ───────────────────
+echo "Assigning RBAC roles to deployer identity..."
+RG_SCOPE="/subscriptions/${SUBSCRIPTION_ID}/resourceGroups/${RESOURCE_GROUP}"
+
+az role assignment create \
+  --assignee "$CLIENT_ID" \
+  --role "Contributor" \
+  --scope "$RG_SCOPE" \
+  --only-show-errors || echo "  Contributor: already assigned or insufficient permission"
+
+az role assignment create \
+  --assignee "$CLIENT_ID" \
+  --role "User Access Administrator" \
+  --scope "$RG_SCOPE" \
+  --only-show-errors || echo "  User Access Administrator: already assigned or insufficient permission"
+
+ACR_SCOPE="${RG_SCOPE}/providers/Microsoft.ContainerRegistry/registries/${ACR_NAME}"
+az role assignment create \
+  --assignee "$CLIENT_ID" \
+  --role "AcrPush" \
+  --scope "$ACR_SCOPE" \
+  --only-show-errors || echo "  AcrPush: already assigned or insufficient permission"
+echo "  3 RBAC roles assigned"
+
 echo ""
 echo "=== Done ==="
 echo ""


### PR DESCRIPTION
## Problem

Deploy failed: deployer SP lacks `Microsoft.Authorization/roleAssignments/write` — needed because Bicep creates role assignments (AcrPull, SQL, KV access).

## Fix

1. **Immediate**: Assigned `User Access Administrator` on `rg-hackops-se-dev` via az CLI
2. **Automated**: Added RBAC assignment block to `setup-github-environments.sh` so future environments get all 3 roles (Contributor + User Access Admin + AcrPush) automatically
3. **Documented**: Updated first-deploy-runbook.md with the missing role